### PR TITLE
docs: add link to nvidia drivers setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ from [this link](https://github.com/gabotechs/MusicGPT/releases/latest/download/
 
 ### Docker (Recommend for running with CUDA)
 
-If you want to run MusicGPT with a CUDA enabled GPU, this is the best way, as you only need to have the basic
-NVIDIA drivers installed in your system.
+If you want to run MusicGPT with a CUDA enabled GPU, this is the best way, as you only need to have [the basic
+NVIDIA drivers installed in your system](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
 
 ```shell
 docker pull gabotechs/musicgpt

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ from [this link](https://github.com/gabotechs/MusicGPT/releases/latest/download/
 ### Docker (Recommend for running with CUDA)
 
 If you want to run MusicGPT with a CUDA enabled GPU, this is the best way, as you only need to have [the basic
-NVIDIA drivers installed in your system](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
+NVIDIA drivers](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed in your system.
 
 ```shell
 docker pull gabotechs/musicgpt


### PR DESCRIPTION
Closes #9 

I just tried to run a docker container and had the same problem as described in issue #9 
I installed drivers and now it works fine. I attach a link on official Nvidia instruction, to save time for a users.