### PR TITLE
Fix generated wav mono center speaker instead of front left

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true,
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,9 +1097,8 @@ dependencies = [
 
 [[package]]
 name = "hound"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+version = "3.4.0"
+source = "git+https://github.com/rubeniskov/hound.git?branch=fix-channel-mask-mono-speaker#5153cbf0c31b1b6a47b45e9171ab1bfd42faae60"
 
 [[package]]
 name = "http"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ndarray = "0.16.1"
 num-traits = "0.2.18"
 log = "0.4.21"
 rand = "0.8.5"
-hound = "3.5.1"
+hound = { git = "https://github.com/rubeniskov/hound.git", branch = "fix-channel-mask-mono-speaker" }
 tokio = { version = "1.37.0", features = ["full"] }
 indicatif = "0.17.8"
 directories = "5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,11 @@ ort = { version = "2.0.0-rc.9", features = ["half", "ndarray"], default-features
 half = { version = "2.4.1", features = ["num-traits"] }
 lazy_static = "1.4.0"
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt", "time"] }
+tracing-subscriber = { version = "0.3.18", features = [
+    "env-filter",
+    "fmt",
+    "time",
+] }
 async-trait = "0.1.80"
 anyhow = "1.0.83"
 uuid = { version = "1.8.0", features = ["v4", "serde"] }
@@ -46,7 +50,12 @@ zip = "2.2.2"
 # Web UI deps, potentially hide behind a flag
 tokio-util = "0.7.11"
 tokio-tungstenite = "0.21.0"
-specta = { version = "1.0.5", features = ["uuid", "serde", "typescript", "export"] }
+specta = { version = "1.0.5", features = [
+    "uuid",
+    "serde",
+    "typescript",
+    "export",
+] }
 axum = { version = "0.7.5", features = ["ws"] }
 tower-http = { version = "0.5.2", features = ["fs"] }
 open = "5.1.2"

--- a/src/audio/audio_manager.rs
+++ b/src/audio/audio_manager.rs
@@ -30,7 +30,9 @@ impl Default for AudioManager {
 
 #[allow(dead_code)]
 pub struct AudioStream {
+    #[allow(dead_code)]
     pub stream: Stream,
+    #[allow(dead_code)]
     pub duration: Duration,
 }
 


### PR DESCRIPTION
## Issue:
https://github.com/gabotechs/MusicGPT/issues/21

## Motivation
Since the repository [ruuda/hound](https://github.com/ruuda/hound) is not frequently maintained, I created this temporary solution to reference a fixed version of `hound`. You can view the fix in [PR #88](https://github.com/ruuda/hound/pull/88).

![image](https://github.com/user-attachments/assets/2001381a-832e-45b5-9b3a-340fbc2eff93)

```shell
diff -u  <(ffprobe musicgen-large-edm-front-left-speaker.wav 2>&1 )  <(ffprobe musicgen-large-edm-center-speaker.wav 2>&1)
```
```diff
--- /dev/fd/63  2024-11-13 17:49:35.739658930 +0100
+++ /dev/fd/62  2024-11-13 17:49:35.739658930 +0100
@@ -8,6 +8,6 @@
   libavfilter     9. 12.100 /  9. 12.100
   libswscale      7.  5.100 /  7.  5.100
   libswresample   4. 12.100 /  4. 12.100
-Input #0, wav, from '/home/rubeniskov/Downloads/musicgen-large-edm-front-left-speaker.wav':
+Input #0, wav, from '/home/rubeniskov/Downloads/musicgen-large-edm-center-speaker.wav':
   Duration: 00:00:29.94, bitrate: 1024 kb/s
-  Stream #0:0: Audio: pcm_f32le ([3][0][0][0] / 0x0003), 32000 Hz, 1 channels (FL), flt, 1024 kb/s
+  Stream #0:0: Audio: pcm_f32le ([3][0][0][0] / 0x0003), 32000 Hz, mono, flt, 1024 kb/s
``